### PR TITLE
Adding a versioned file for members

### DIFF
--- a/docs/members.md
+++ b/docs/members.md
@@ -1,7 +1,7 @@
 # Members
 
-- @matteodelabre
-- @raisjn
-- @Eeems
-- @LinusCDE
-- @dixonary
+- [@matteodelabre](https://github.com/)
+- [@raisjn](https://github.com/raisjn)
+- [@Eeems](https://github.com/Eeems)
+- [@LinusCDE](https://github.com/LinusCDE)
+- [@dixonary](https://github.com/dixonary)

--- a/docs/members.md
+++ b/docs/members.md
@@ -1,6 +1,6 @@
 # Members
 
-- [@matteodelabre](https://github.com/)
+- [@matteodelabre](https://github.com/matteodelabre)
 - [@raisjn](https://github.com/raisjn)
 - [@Eeems](https://github.com/Eeems)
 - [@LinusCDE](https://github.com/LinusCDE)

--- a/docs/members.md
+++ b/docs/members.md
@@ -1,0 +1,7 @@
+# Members
+
+- @matteodelabre
+- @raisjn
+- @Eeems
+- @LinusCDE
+- @dixonary


### PR DESCRIPTION
As discussed in todays meeting.

Advantages:
 - See when people were added by looking at the files commit history
 - Propose adding new members by pr

For now I just added the gh tags. My initial idea was a `.txt` with `Name <mail@domain.tld>` per entry but not sure if everyone want's his email listed. Maybe another format? I'm open for discussion/suggestions 

(The order is my presumed order of entry for the members. If we decide on adding people only to the toltec repo, maybe we should add types/categories of members later on.)